### PR TITLE
Add DBScan clustering algorithm

### DIFF
--- a/src/clusters/__test__/dbscan.test.ts
+++ b/src/clusters/__test__/dbscan.test.ts
@@ -1,0 +1,37 @@
+import { DBScan } from '../dbscan';
+
+function makeCircles(n1: number, n2: number, r1: number, r2: number): number[][] {
+    const data: number[][] = [];
+    for (let i = 0; i < n1; i++) {
+        const angle = (2 * Math.PI * i) / n1;
+        data.push([r1 * Math.cos(angle), r1 * Math.sin(angle)]);
+    }
+    for (let j = 0; j < n2; j++) {
+        const angle = (2 * Math.PI * j) / n2;
+        data.push([r2 * Math.cos(angle), r2 * Math.sin(angle)]);
+    }
+    return data;
+}
+
+function reAssignLabel(labels: number[]): number[] {
+    const encoder: Map<number, number> = new Map();
+    let ans: number[] = [];
+    let counter = 0;
+    for (let i = 0; i < labels.length; i++) {
+        if (!encoder.has(labels[i])) {
+            encoder.set(labels[i], counter++);
+        }
+        ans.push(encoder.get(labels[i])!);
+    }
+    return ans;
+}
+
+test('dbscan two circles', () => {
+    const X = makeCircles(20, 20, 1, 5);
+    const dbscan = new DBScan(0.6, 3);
+    const labels = reAssignLabel(dbscan.fitPredict(X));
+    const expected: number[] = [];
+    for (let i = 0; i < 20; i++) expected.push(0);
+    for (let i = 0; i < 20; i++) expected.push(1);
+    expect(labels).toEqual(expected);
+});

--- a/src/clusters/dbscan.ts
+++ b/src/clusters/dbscan.ts
@@ -1,0 +1,63 @@
+import { ClusterBase } from '../base/cluster';
+import { Distance } from '../metrics';
+
+export class DBScan extends ClusterBase {
+    private eps: number;
+    private minSamples: number;
+    private distance: Distance.IDistance;
+    constructor(eps: number = 0.5, minSamples: number = 5, distanceType: Distance.IDistanceType = 'euclidiean') {
+        super();
+        this.eps = eps;
+        this.minSamples = minSamples;
+        this.distance = Distance.useDistance(distanceType);
+    }
+
+    public fitPredict(samplesX: number[][]): number[] {
+        const labels: Array<number | undefined> = new Array(samplesX.length);
+        const visited: boolean[] = new Array(samplesX.length).fill(false);
+        let clusterId = 0;
+        for (let i = 0; i < samplesX.length; i++) {
+            if (visited[i]) continue;
+            visited[i] = true;
+            const neighbors = this.regionQuery(samplesX, i);
+            if (neighbors.length < this.minSamples) {
+                labels[i] = -1;
+            } else {
+                this.expandCluster(samplesX, i, neighbors, clusterId, labels, visited);
+                clusterId++;
+            }
+        }
+        return labels as number[];
+    }
+
+    private expandCluster(samplesX: number[][], pointIndex: number, neighbors: number[], clusterId: number, labels: Array<number | undefined>, visited: boolean[]) {
+        labels[pointIndex] = clusterId;
+        for (let i = 0; i < neighbors.length; i++) {
+            const nIndex = neighbors[i];
+            if (!visited[nIndex]) {
+                visited[nIndex] = true;
+                const nNeighbors = this.regionQuery(samplesX, nIndex);
+                if (nNeighbors.length >= this.minSamples) {
+                    for (const nb of nNeighbors) {
+                        if (neighbors.indexOf(nb) === -1) {
+                            neighbors.push(nb);
+                        }
+                    }
+                }
+            }
+            if (labels[nIndex] === undefined || labels[nIndex] === -1) {
+                labels[nIndex] = clusterId;
+            }
+        }
+    }
+
+    private regionQuery(samplesX: number[][], index: number): number[] {
+        const neighbors: number[] = [];
+        for (let i = 0; i < samplesX.length; i++) {
+            if (this.distance(samplesX[index], samplesX[i]) <= this.eps) {
+                neighbors.push(i);
+            }
+        }
+        return neighbors;
+    }
+}

--- a/src/clusters/index.ts
+++ b/src/clusters/index.ts
@@ -1,3 +1,4 @@
 import { KMeans } from './kmeans';
+import { DBScan } from './dbscan';
 
-export { KMeans }
+export { KMeans, DBScan }


### PR DESCRIPTION
## Summary
- implement DBScan clustering algorithm
- export DBScan in cluster index
- add tests for DBScan on two-circle dataset

## Testing
- `npm test` *(fails: jest not found)*