### PR TITLE
Add SVM classifiers

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -18,3 +18,8 @@
     
     + [Linear](./apis/linear/index.md)
         + [Linear Regression](./apis/linear/linearRegression.md)
+
+    + [SVM](./apis/svm/index.md)
+        + [SVC](./apis/svm/SVC.md)
+        + [NuSVC](./apis/svm/NuSVC.md)
+        + [LinearSVC](./apis/svm/LinearSVC.md)

--- a/docs/apis/svm/LinearSVC.md
+++ b/docs/apis/svm/LinearSVC.md
@@ -1,0 +1,17 @@
+## LinearSVC
+
+```ts
+interface LinearSVCProps {
+    C?: number;
+    maxIter?: number;
+    learningRate?: number;
+}
+constructor(props: LinearSVCProps = {})
+```
+
+### Example
+```ts
+const svc = new LinearSVC();
+svc.fit(X, y);
+const result = svc.predict(T);
+```

--- a/docs/apis/svm/NuSVC.md
+++ b/docs/apis/svm/NuSVC.md
@@ -1,0 +1,10 @@
+## NuSVC
+
+```ts
+interface NuSVCProps {
+    nu?: number;
+}
+constructor(props: NuSVCProps = {})
+```
+
+NuSVC shares the same usage as `SVC` but uses the `nu` parameter instead of `C`.

--- a/docs/apis/svm/SVC.md
+++ b/docs/apis/svm/SVC.md
@@ -1,0 +1,19 @@
+## SVC
+
+```ts
+interface SVCProps {
+    C?: number;
+    maxIter?: number;
+    learningRate?: number;
+    kernel?: 'linear' | 'rbf';
+    gamma?: number;
+}
+constructor(props: SVCProps = {})
+```
+
+### Example
+```ts
+const svc = new SVC({ kernel: 'linear' });
+svc.fit(X, y);
+const result = svc.predict(T);
+```

--- a/docs/apis/svm/index.md
+++ b/docs/apis/svm/index.md
@@ -1,0 +1,5 @@
+# SVM
+
+- [SVC](SVC.md)
+- [NuSVC](NuSVC.md)
+- [LinearSVC](LinearSVC.md)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import * as Algebra from './algebra';
 import * as KMath from './math';
 import * as Tree from './tree/index';
 import * as Linear from './linear';
+import * as SVM from './svm';
 
 export {
     Tree,
@@ -13,5 +14,6 @@ export {
     Clusters,
     Algebra,
     KMath,
-    Linear
+    Linear,
+    SVM
 }

--- a/src/svm/__test__/svc.test.ts
+++ b/src/svm/__test__/svc.test.ts
@@ -1,0 +1,39 @@
+import { SVC } from '../svc';
+import { LinearSVC } from '../linearSVC';
+import { NuSVC } from '../nuSVC';
+
+test('linear svc basic', () => {
+    const X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]];
+    const y = [0, 0, 0, 1, 1, 1];
+    const T = [[-1, -1], [2, 2], [3, 2]];
+    const trueResult = [0, 1, 1];
+
+    const svc = new SVC({ kernel: 'linear', maxIter: 50, learningRate: 0.1 });
+    svc.fit(X, y);
+    const ans = svc.predict(T);
+    expect(ans).toEqual(trueResult);
+});
+
+test('nu svc basic', () => {
+    const X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]];
+    const y = [0, 0, 0, 1, 1, 1];
+    const T = [[-1, -1], [2, 2], [3, 2]];
+    const trueResult = [0, 1, 1];
+
+    const svc = new NuSVC({ kernel: 'linear', maxIter: 50, learningRate: 0.1 });
+    svc.fit(X, y);
+    const ans = svc.predict(T);
+    expect(ans).toEqual(trueResult);
+});
+
+test('linearSVC basic', () => {
+    const X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]];
+    const y = [0, 0, 0, 1, 1, 1];
+    const T = [[-1, -1], [2, 2], [3, 2]];
+    const trueResult = [0, 1, 1];
+
+    const svc = new LinearSVC({ maxIter: 50, learningRate: 0.1 });
+    svc.fit(X, y);
+    const ans = svc.predict(T);
+    expect(ans).toEqual(trueResult);
+});

--- a/src/svm/index.ts
+++ b/src/svm/index.ts
@@ -1,0 +1,3 @@
+export { SVC } from './svc';
+export { NuSVC } from './nuSVC';
+export { LinearSVC } from './linearSVC';

--- a/src/svm/linearSVC.ts
+++ b/src/svm/linearSVC.ts
@@ -1,0 +1,85 @@
+import { ClassifierBase } from '../base';
+
+export interface LinearSVCProps {
+    C?: number;
+    maxIter?: number;
+    learningRate?: number;
+}
+
+export class LinearSVC extends ClassifierBase {
+    private C: number;
+    private maxIter: number;
+    private learningRate: number;
+    private classes: number[];
+    private weights: number[][];
+    private biases: number[];
+
+    constructor(props: LinearSVCProps = {}) {
+        super();
+        const { C = 1, maxIter = 100, learningRate = 0.01 } = props;
+        this.C = C;
+        this.maxIter = maxIter;
+        this.learningRate = learningRate;
+        this.classes = [];
+        this.weights = [];
+        this.biases = [];
+    }
+
+    public fit(trainX: number[][], trainY: number[]): void {
+        this.classes = Array.from(new Set(trainY));
+        const nFeatures = trainX[0].length;
+        this.weights = [];
+        this.biases = [];
+        for (let k = 0; k < this.classes.length; k++) {
+            const cls = this.classes[k];
+            let w = new Array(nFeatures).fill(0);
+            let b = 0;
+            const y = trainY.map(v => (v === cls ? 1 : -1));
+            for (let iter = 0; iter < this.maxIter; iter++) {
+                for (let i = 0; i < trainX.length; i++) {
+                    const xi = trainX[i];
+                    const yi = y[i];
+                    let wx = 0;
+                    for (let j = 0; j < nFeatures; j++) {
+                        wx += w[j] * xi[j];
+                    }
+                    wx += b;
+                    if (yi * wx < 1) {
+                        for (let j = 0; j < nFeatures; j++) {
+                            w[j] = w[j] - this.learningRate * (w[j] - this.C * yi * xi[j]);
+                        }
+                        b += this.learningRate * this.C * yi;
+                    } else {
+                        for (let j = 0; j < nFeatures; j++) {
+                            w[j] = w[j] - this.learningRate * w[j];
+                        }
+                    }
+                }
+            }
+            this.weights.push(w);
+            this.biases.push(b);
+        }
+    }
+
+    public predict(testX: number[][]): number[] {
+        const results: number[] = [];
+        for (const x of testX) {
+            let bestIndex = 0;
+            let bestScore = -Infinity;
+            for (let k = 0; k < this.classes.length; k++) {
+                const w = this.weights[k];
+                const b = this.biases[k];
+                let score = b;
+                for (let j = 0; j < x.length; j++) {
+                    score += w[j] * x[j];
+                }
+                if (score > bestScore) {
+                    bestScore = score;
+                    bestIndex = k;
+                }
+            }
+            results.push(this.classes[bestIndex]);
+        }
+        return results;
+    }
+}

--- a/src/svm/nuSVC.ts
+++ b/src/svm/nuSVC.ts
@@ -1,0 +1,15 @@
+import { SVC, SVCProps } from './svc';
+
+export interface NuSVCProps extends SVCProps {
+    nu?: number;
+}
+
+export class NuSVC extends SVC {
+    private nu: number;
+    constructor(props: NuSVCProps = {}) {
+        const { nu = 0.5, ...rest } = props;
+        const C = rest.C !== undefined ? rest.C : 1 / nu;
+        super({ ...rest, C });
+        this.nu = nu;
+    }
+}

--- a/src/svm/svc.ts
+++ b/src/svm/svc.ts
@@ -1,0 +1,54 @@
+import { ClassifierBase } from '../base';
+import { LinearSVC, LinearSVCProps } from './linearSVC';
+
+export interface SVCProps extends LinearSVCProps {
+    kernel?: 'linear' | 'rbf';
+    gamma?: number;
+}
+
+function rbf(x1: number[], x2: number[], gamma: number): number {
+    let sum = 0;
+    for (let i = 0; i < x1.length; i++) {
+        const d = x1[i] - x2[i];
+        sum += d * d;
+    }
+    return Math.exp(-gamma * sum);
+}
+
+export class SVC extends ClassifierBase {
+    private svc: LinearSVC;
+    private kernel: 'linear' | 'rbf';
+    private gamma: number;
+    private trainX: number[][];
+
+    constructor(props: SVCProps = {}) {
+        super();
+        const { kernel = 'rbf', gamma = 1, ...rest } = props;
+        this.kernel = kernel;
+        this.gamma = gamma;
+        this.svc = new LinearSVC(rest);
+        this.trainX = [];
+    }
+
+    private transform(X: number[][]): number[][] {
+        return X.map(x => this.trainX.map(tx => rbf(x, tx, this.gamma)));
+    }
+
+    public fit(trainX: number[][], trainY: number[]): void {
+        this.trainX = trainX;
+        if (this.kernel === 'linear') {
+            this.svc.fit(trainX, trainY);
+        } else {
+            const gram = this.transform(trainX);
+            this.svc.fit(gram, trainY);
+        }
+    }
+
+    public predict(testX: number[][]): number[] {
+        if (this.kernel === 'linear') {
+            return this.svc.predict(testX);
+        }
+        const features = this.transform(testX);
+        return this.svc.predict(features);
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple LinearSVC with hinge loss training
- implement SVC and NuSVC built on LinearSVC
- export SVM module and document SVM APIs
- add unit tests for the new classifiers

## Testing
- `npm run test`