### PR TITLE
Fix docs path for GitHub Pages

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -18,7 +18,7 @@
       loadSidebar: true,
       loadNavbar: true,
       fallbackLanguages: ['en'],
-      routerMode: 'history',
+      routerMode: 'hash',
     }
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
       loadSidebar: true,
       loadNavbar: true,
       fallbackLanguages: ['en'],
-      routerMode: 'history',
+      routerMode: 'hash',
     }
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>


### PR DESCRIPTION
## Summary
- use hash routing so docs work on GitHub Pages

## Testing
- `npm run test`
