### PR TITLE
Add BernoulliNB classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - Classification and regression trees
 - k-nearest neighbors
 - Support vector machines
+- Naive Bayes classifier
 - Clustering algorithms (KMeans, DBSCAN, OPTICS, Mean Shift, HDBSCAN)
 - Dimensionality reduction (PCA)
 - Manifold learning (t-SNE)

--- a/docs/content/docs/apis/bayes/bernoulliNB.md
+++ b/docs/content/docs/apis/bayes/bernoulliNB.md
@@ -1,0 +1,23 @@
+---
+title: BernoulliNB
+description: API reference for BernoulliNB
+---
+
+# Bayes.BernoulliNB
+
+```ts
+interface BernoulliNBProps {
+    alpha?: number;
+    binarize?: number | null;
+    fitPrior?: boolean;
+    classPrior?: number[] | null;
+}
+constructor(props: BernoulliNBProps = {})
+```
+
+### Example
+```ts
+const clf = new BernoulliNB();
+clf.fit(trainX, trainY);
+const result = clf.predict(testX);
+```

--- a/docs/content/docs/apis/bayes/index.md
+++ b/docs/content/docs/apis/bayes/index.md
@@ -1,0 +1,6 @@
+---
+title: Bayes
+description: API reference for Naive Bayes classifiers
+---
+
+- [BernoulliNB](bernoulliNB.md)

--- a/docs/content/docs/apis/index.md
+++ b/docs/content/docs/apis/index.md
@@ -13,3 +13,4 @@ description: Machine learning API documentation
 - [Neighbors](neighbors/index.md)
 - [SVM](svm/index.md)
 - [Tree](tree/index.md)
+- [Bayes](bayes/index.md)

--- a/scripts/gen_all.py
+++ b/scripts/gen_all.py
@@ -16,6 +16,7 @@ scripts = [
     'gen_dbscan.py',
     'gen_optics.py',
     'gen_logistic_regression.py',
+    'gen_bernoulli_nb.py',
     'gen_svc.py',
     'gen_pca.py',
     'gen_spectral_embedding.py',

--- a/scripts/gen_bernoulli_nb.py
+++ b/scripts/gen_bernoulli_nb.py
@@ -1,0 +1,21 @@
+from sklearn.naive_bayes import BernoulliNB
+import numpy as np
+import json
+import os
+
+rng = np.random.RandomState(0)
+X = rng.randint(2, size=(30, 5))
+y = rng.randint(2, size=30)
+X_test = rng.randint(2, size=(10, 5))
+clf = BernoulliNB()
+clf.fit(X, y)
+pred = clf.predict(X_test)
+
+os.makedirs('test_data', exist_ok=True)
+with open('test_data/bernoulli_nb.json', 'w') as f:
+    json.dump({
+        'trainX': X.tolist(),
+        'trainY': y.tolist(),
+        'testX': X_test.tolist(),
+        'expected': pred.tolist()
+    }, f)

--- a/src/bayes/__test__/bernoulliNB.compare.test.ts
+++ b/src/bayes/__test__/bernoulliNB.compare.test.ts
@@ -1,0 +1,12 @@
+import { BernoulliNB } from '../bernoulliNB';
+import fs from 'fs';
+import path from 'path';
+
+test('compare with sklearn', () => {
+    const p = path.join(__dirname, '../../../test_data/bernoulli_nb.json');
+    const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+    const clf = new BernoulliNB();
+    clf.fit(data.trainX, data.trainY);
+    const pred = clf.predict(data.testX);
+    expect(pred).toEqual(data.expected);
+});

--- a/src/bayes/__test__/bernoulliNB.test.ts
+++ b/src/bayes/__test__/bernoulliNB.test.ts
@@ -1,0 +1,20 @@
+import { BernoulliNB } from '../bernoulliNB';
+
+test('init', () => {
+    const nb = new BernoulliNB();
+    expect(nb).toBeDefined();
+});
+
+test('simple classification', () => {
+    const X = [
+        [0, 0],
+        [1, 0],
+        [0, 1],
+        [1, 1]
+    ];
+    const Y = [0, 0, 1, 1];
+    const nb = new BernoulliNB();
+    nb.fit(X, Y);
+    const pred = nb.predict(X);
+    expect(pred).toEqual(Y);
+});

--- a/src/bayes/bernoulliNB.ts
+++ b/src/bayes/bernoulliNB.ts
@@ -1,0 +1,119 @@
+import { ClassifierBase } from '../base';
+
+export interface BernoulliNBProps {
+    alpha?: number;
+    binarize?: number | null;
+    fitPrior?: boolean;
+    classPrior?: number[] | null;
+}
+
+export class BernoulliNB extends ClassifierBase {
+    private alpha: number;
+    private binarize: number | null;
+    private fitPrior: boolean;
+    private classPrior: number[] | null;
+
+    private classes: number[] = [];
+    private classCount: number[] = [];
+    private featureCount: number[][] = [];
+    private classLogPrior: number[] = [];
+    private featureLogProb: number[][] = [];
+    private negLogProb: number[][] = [];
+
+    constructor(props: BernoulliNBProps = {}) {
+        super();
+        const { alpha = 1.0, binarize = 0.0, fitPrior = true, classPrior = null } = props;
+        this.alpha = alpha;
+        this.binarize = binarize;
+        this.fitPrior = fitPrior;
+        this.classPrior = classPrior;
+    }
+
+    private binarizeX(X: number[][]): number[][] {
+        if (this.binarize === null) return X.map(r => r.slice());
+        const threshold = this.binarize;
+        return X.map(row => row.map(v => (v > threshold ? 1 : 0)));
+    }
+
+    public fit(trainX: number[][], trainY: number[]): void {
+        const X = this.binarizeX(trainX);
+        this.classes = Array.from(new Set(trainY)).sort((a, b) => a - b);
+        const nClasses = this.classes.length;
+        const nFeatures = X[0].length;
+
+        this.classCount = new Array(nClasses).fill(0);
+        this.featureCount = Array.from({ length: nClasses }, () => new Array(nFeatures).fill(0));
+
+        const classIndex = new Map<number, number>();
+        this.classes.forEach((c, i) => classIndex.set(c, i));
+
+        for (let i = 0; i < X.length; i++) {
+            const idx = classIndex.get(trainY[i])!;
+            this.classCount[idx] += 1;
+            for (let j = 0; j < nFeatures; j++) {
+                this.featureCount[idx][j] += X[i][j];
+            }
+        }
+
+        // class log prior
+        if (this.classPrior) {
+            this.classLogPrior = this.classPrior.map(p => Math.log(p));
+        } else if (this.fitPrior) {
+            const totalCount = this.classCount.reduce((a, b) => a + b, 0);
+            this.classLogPrior = this.classCount.map(c => Math.log((c + this.alpha) / (totalCount + nClasses * this.alpha)));
+        } else {
+            this.classLogPrior = new Array(nClasses).fill(Math.log(1 / nClasses));
+        }
+
+        // feature log prob
+        this.featureLogProb = Array.from({ length: nClasses }, () => new Array(nFeatures).fill(0));
+        this.negLogProb = Array.from({ length: nClasses }, () => new Array(nFeatures).fill(0));
+        for (let i = 0; i < nClasses; i++) {
+            for (let j = 0; j < nFeatures; j++) {
+                const fc = this.featureCount[i][j];
+                const cc = this.classCount[i];
+                const prob = (fc + this.alpha) / (cc + 2 * this.alpha);
+                this.featureLogProb[i][j] = Math.log(prob);
+                this.negLogProb[i][j] = Math.log(1 - prob);
+            }
+        }
+    }
+
+    private jointLogLikelihood(X: number[][]): number[][] {
+        const nSamples = X.length;
+        const nClasses = this.classes.length;
+        const jll: number[][] = Array.from({ length: nSamples }, () => new Array(nClasses).fill(0));
+        for (let i = 0; i < nSamples; i++) {
+            for (let c = 0; c < nClasses; c++) {
+                let sum = this.classLogPrior[c];
+                for (let j = 0; j < X[i].length; j++) {
+                    if (X[i][j]) {
+                        sum += this.featureLogProb[c][j];
+                    } else {
+                        sum += this.negLogProb[c][j];
+                    }
+                }
+                jll[i][c] = sum;
+            }
+        }
+        return jll;
+    }
+
+    public predict(testX: number[][]): number[] {
+        const X = this.binarizeX(testX);
+        const jll = this.jointLogLikelihood(X);
+        const preds: number[] = [];
+        for (const row of jll) {
+            let best = 0;
+            let max = row[0];
+            for (let i = 1; i < row.length; i++) {
+                if (row[i] > max) {
+                    max = row[i];
+                    best = i;
+                }
+            }
+            preds.push(this.classes[best]);
+        }
+        return preds;
+    }
+}

--- a/src/bayes/index.ts
+++ b/src/bayes/index.ts
@@ -1,0 +1,1 @@
+export { BernoulliNB } from './bernoulliNB';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import * as Linear from './linear';
 import * as SVM from './svm';
 import * as Decomposition from './decomposition';
 import * as Manifold from './manifold';
+import * as Bayes from './bayes';
 
 export {
     Tree,
@@ -19,5 +20,6 @@ export {
     Linear,
     SVM,
     Decomposition,
-    Manifold
+    Manifold,
+    Bayes
 }


### PR DESCRIPTION
## Summary
- implement BernoulliNB classifier
- support data generation script for test parity with sklearn
- expose Bayes module and document BernoulliNB API
- add unit tests comparing to sklearn
- mention Naive Bayes in README

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_683b1fe93d4c8322aff98b36d320863c