### PR TITLE
Add BallTree neighbors algorithm

### DIFF
--- a/docs/content/docs/apis/neighbors/ballTree.md
+++ b/docs/content/docs/apis/neighbors/ballTree.md
@@ -1,0 +1,25 @@
+---
+title: BallTree
+description: API reference for BallTree
+---
+
+# Neighbors.BallTree
+
+```ts
+constructor(
+    X: number[][] = [],
+    leafSize: number = 40,
+    metric: Distance.IDistanceType = 'euclidiean',
+    p: number = 2
+)
+```
+
+`query(X: number[][], k: number = 1)` returns distances and indices of nearest neighbors.
+
+`queryRadius(X: number[][], r: number, returnDistance = false)` finds neighbors within given radius.
+
+### Example
+```ts
+const tree = new BallTree(X, 2);
+const result = tree.query(X.slice(0, 1), 3);
+```

--- a/docs/content/docs/apis/neighbors/index.md
+++ b/docs/content/docs/apis/neighbors/index.md
@@ -4,3 +4,4 @@ description: API reference for Neighbors
 ---
 
 - [KNearstNeighbors](knn.md)
+- [BallTree](ballTree.md)

--- a/scripts/gen_all.py
+++ b/scripts/gen_all.py
@@ -11,6 +11,7 @@ scripts = [
     'gen_decision_tree_regressor.py',
     'gen_isolation_forest.py',
     'gen_knn.py',
+    'gen_ball_tree.py',
     'gen_kmeans.py',
     'gen_mean_shift.py',
     'gen_dbscan.py',

--- a/scripts/gen_ball_tree.py
+++ b/scripts/gen_ball_tree.py
@@ -1,0 +1,27 @@
+import numpy as np
+from sklearn.neighbors import BallTree
+import json, os
+
+rng = np.random.RandomState(0)
+X = rng.random_sample((20, 3))
+leaf_size = 2
+k = 3
+test = rng.random_sample((5, 3))
+radius = 0.3
+tree = BallTree(X, leaf_size=leaf_size)
+dist, ind = tree.query(test, k=k)
+ind_r, dist_r = tree.query_radius(test, r=radius, return_distance=True)
+
+os.makedirs('test_data', exist_ok=True)
+with open('test_data/balltree.json', 'w') as f:
+    json.dump({
+        'X': X.tolist(),
+        'leaf_size': leaf_size,
+        'test': test.tolist(),
+        'k': k,
+        'radius': radius,
+        'query_indices': ind.tolist(),
+        'query_distances': dist.tolist(),
+        'radius_indices': [i.tolist() for i in ind_r],
+        'radius_distances': [d.tolist() for d in dist_r]
+    }, f)

--- a/src/neighbors/__test__/ballTree.compare.test.ts
+++ b/src/neighbors/__test__/ballTree.compare.test.ts
@@ -1,0 +1,30 @@
+import { BallTree } from '../ballTree';
+import fs from 'fs';
+import path from 'path';
+
+test('compare with sklearn', () => {
+    const p = path.join(__dirname, '../../../test_data/balltree.json');
+    const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+    const tree = new BallTree(data.X, data.leaf_size);
+    const q = tree.query(data.test, data.k);
+    for (let i = 0; i < data.test.length; i++) {
+        for (let j = 0; j < data.k; j++) {
+            expect(q.indices[i][j]).toBe(data.query_indices[i][j]);
+            expect(q.distances[i][j]).toBeCloseTo(data.query_distances[i][j], 6);
+        }
+    }
+    const r = tree.queryRadius(data.test, data.radius, true) as {
+        indices: number[][];
+        distances: number[][];
+    };
+    for (let i = 0; i < data.test.length; i++) {
+        const idx = [...r.indices[i]].sort((a, b) => a - b);
+        const idxExp = [...data.radius_indices[i]].sort((a, b) => a - b);
+        expect(idx).toEqual(idxExp);
+        const dist = [...r.distances[i]].sort((a, b) => a - b);
+        const distExp = [...data.radius_distances[i]].sort((a, b) => a - b);
+        for (let j = 0; j < dist.length; j++) {
+            expect(dist[j]).toBeCloseTo(distExp[j], 6);
+        }
+    }
+});

--- a/src/neighbors/__test__/ballTree.test.ts
+++ b/src/neighbors/__test__/ballTree.test.ts
@@ -1,0 +1,19 @@
+import { BallTree } from '../ballTree';
+
+test('init', () => {
+    const tree = new BallTree();
+    expect(tree).toBeDefined();
+});
+
+test('basic query', () => {
+    const X = [
+        [0, 0],
+        [1, 0],
+        [0, 1],
+        [1, 1]
+    ];
+    const tree = new BallTree(X, 1);
+    const { indices } = tree.query([[0, 0]], 2);
+    expect(indices[0][0]).toBe(0);
+    expect([1, 2]).toContain(indices[0][1]);
+});

--- a/src/neighbors/ballTree.ts
+++ b/src/neighbors/ballTree.ts
@@ -1,0 +1,182 @@
+import { Distance } from '../metrics';
+
+interface BallNode {
+    centroid: number[];
+    radius: number;
+    indices: number[];
+    left: BallNode | null;
+    right: BallNode | null;
+}
+
+export class BallTree {
+    private X: number[][];
+    private leafSize: number;
+    private root: BallNode | null;
+    private distance: Distance.IDistance;
+    private p: number;
+
+    constructor(
+        X: number[][] = [],
+        leafSize: number = 40,
+        metric: Distance.IDistanceType = 'euclidiean',
+        p: number = 2
+    ) {
+        this.X = X;
+        this.leafSize = leafSize;
+        this.distance = Distance.useDistance(metric);
+        this.p = p;
+        this.root = null;
+        if (X.length > 0) {
+            this.root = this.buildTree(Array.from({ length: X.length }, (_, i) => i));
+        }
+    }
+
+    public fit(X: number[][]): void {
+        this.X = X;
+        this.root = this.buildTree(Array.from({ length: X.length }, (_, i) => i));
+    }
+
+    public query(X: number[][], k: number = 1): { distances: number[][]; indices: number[][] } {
+        return {
+            distances: X.map((x) => {
+                const heap: Array<{ dist: number; idx: number }> = [];
+                if (this.root) this._query(this.root, x, k, heap);
+                return heap.map((h) => h.dist);
+            }),
+            indices: X.map((x) => {
+                const heap: Array<{ dist: number; idx: number }> = [];
+                if (this.root) this._query(this.root, x, k, heap);
+                return heap.map((h) => h.idx);
+            }),
+        };
+    }
+
+    public queryRadius(
+        X: number[][],
+        r: number,
+        returnDistance: boolean = false
+    ): number[][] | { indices: number[][]; distances: number[][] } {
+        const ind: number[][] = [];
+        const dist: number[][] = [];
+        for (const x of X) {
+            const iArr: number[] = [];
+            const dArr: number[] = [];
+            if (this.root) this._queryRadius(this.root, x, r, iArr, dArr, returnDistance);
+            ind.push(iArr);
+            dist.push(dArr);
+        }
+        if (returnDistance) {
+            for (let i = 0; i < ind.length; i++) {
+                const arr = ind[i].map((idx, j) => ({ idx, dist: dist[i][j] }));
+                arr.sort((a, b) => a.dist - b.dist);
+                ind[i] = arr.map((a) => a.idx);
+                dist[i] = arr.map((a) => a.dist);
+            }
+            return { indices: ind, distances: dist };
+        }
+        return ind;
+    }
+
+    private _query(node: BallNode, x: number[], k: number, heap: Array<{ dist: number; idx: number }>): void {
+        if (!node.left && !node.right) {
+            for (const idx of node.indices) {
+                const d = this.distance(x, this.X[idx], this.p);
+                this.pushHeap(heap, { dist: d, idx }, k);
+            }
+            return;
+        }
+        if (node.left) {
+            const leftBound = Math.max(
+                0,
+                this.distance(x, node.left.centroid, this.p) - node.left.radius
+            );
+            const rightBound = node.right
+                ? Math.max(0, this.distance(x, node.right.centroid, this.p) - node.right.radius)
+                : Infinity;
+            if (leftBound < rightBound) {
+                this._query(node.left, x, k, heap);
+                if (node.right && (heap.length < k || rightBound <= heap[heap.length - 1].dist)) {
+                    this._query(node.right, x, k, heap);
+                }
+            } else {
+                if (node.right) this._query(node.right, x, k, heap);
+                if (heap.length < k || leftBound <= heap[heap.length - 1].dist) {
+                    this._query(node.left, x, k, heap);
+                }
+            }
+        }
+    }
+
+    private _queryRadius(
+        node: BallNode,
+        x: number[],
+        r: number,
+        ind: number[],
+        dist: number[],
+        keepDist: boolean
+    ): void {
+        const dCentroid = this.distance(x, node.centroid, this.p);
+        if (dCentroid - node.radius > r) return;
+        if (!node.left && !node.right) {
+            for (const idx of node.indices) {
+                const d = this.distance(x, this.X[idx], this.p);
+                if (d <= r) {
+                    ind.push(idx);
+                    if (keepDist) dist.push(d);
+                }
+            }
+            return;
+        }
+        if (node.left) this._queryRadius(node.left, x, r, ind, dist, keepDist);
+        if (node.right) this._queryRadius(node.right, x, r, ind, dist, keepDist);
+    }
+
+    private pushHeap(
+        heap: Array<{ dist: number; idx: number }>,
+        item: { dist: number; idx: number },
+        k: number
+    ): void {
+        let pos = 0;
+        while (pos < heap.length && heap[pos].dist < item.dist) pos++;
+        heap.splice(pos, 0, item);
+        if (heap.length > k) heap.pop();
+    }
+
+    private buildTree(indices: number[]): BallNode {
+        const centroid = new Array(this.X[0].length).fill(0);
+        for (const i of indices) {
+            const row = this.X[i];
+            for (let d = 0; d < row.length; d++) centroid[d] += row[d];
+        }
+        for (let d = 0; d < centroid.length; d++) centroid[d] /= indices.length;
+
+        let radius = 0;
+        for (const i of indices) {
+            const d = this.distance(centroid, this.X[i], this.p);
+            if (d > radius) radius = d;
+        }
+        if (indices.length <= this.leafSize) {
+            return { centroid, radius, indices, left: null, right: null };
+        }
+        let bestDim = 0;
+        let bestVar = -Infinity;
+        for (let d = 0; d < centroid.length; d++) {
+            let mean = 0;
+            for (const i of indices) mean += this.X[i][d];
+            mean /= indices.length;
+            let v = 0;
+            for (const i of indices) v += (this.X[i][d] - mean) ** 2;
+            if (v > bestVar) {
+                bestVar = v;
+                bestDim = d;
+            }
+        }
+        indices.sort((a, b) => this.X[a][bestDim] - this.X[b][bestDim]);
+        const mid = Math.floor(indices.length / 2);
+        const leftIdx = indices.slice(0, mid);
+        const rightIdx = indices.slice(mid);
+        const left = this.buildTree(leftIdx);
+        const right = this.buildTree(rightIdx);
+        return { centroid, radius, indices: [], left, right };
+    }
+}

--- a/src/neighbors/index.ts
+++ b/src/neighbors/index.ts
@@ -1,1 +1,2 @@
 export { KNearstNeighbors } from './knn';
+export { BallTree } from './ballTree';


### PR DESCRIPTION
## Summary
- implement BallTree for nearest neighbour queries
- generate sklearn reference data for BallTree
- export BallTree API
- test BallTree behaviour and compare with sklearn
- document BallTree usage

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_683b1f964fa48322b23fde20b2b6feaa