### PR TITLE
Add asyncMode tests and docs

### DIFF
--- a/docs/content/docs/apis/index.md
+++ b/docs/content/docs/apis/index.md
@@ -14,3 +14,4 @@ description: Machine learning API documentation
 - [SVM](svm/index.md)
 - [Tree](tree/index.md)
 - [Bayes](bayes/index.md)
+- [Utils](utils/index.md)

--- a/docs/content/docs/apis/utils/asyncMode.md
+++ b/docs/content/docs/apis/utils/asyncMode.md
@@ -1,0 +1,20 @@
+---
+title: asyncMode
+description: Run a synchronous function in a worker
+---
+
+# Utils.asyncMode
+
+```ts
+asyncMode<P extends any[], R>(fn: (...args: P) => R): (...args: P) => Promise<R>
+```
+
+This helper wraps a synchronous function so it runs in a Web Worker in the browser or a worker thread in Node.js.
+
+```ts
+const heavy = (x: number) => x * x;
+const runAsync = asyncMode(heavy);
+const result = await runAsync(5);
+```
+
+This function is useful for CPU intensive operations.

--- a/docs/content/docs/apis/utils/index.md
+++ b/docs/content/docs/apis/utils/index.md
@@ -1,0 +1,6 @@
+---
+title: Utils
+description: Utility functions for the ml library
+---
+
+- [asyncMode](asyncMode.md)

--- a/src/utils/__test__/asyncMode.test.ts
+++ b/src/utils/__test__/asyncMode.test.ts
@@ -1,0 +1,14 @@
+import { asyncMode } from '../asyncMode';
+
+test('asyncMode resolves result', async () => {
+    const sum = (a: number, b: number) => a + b;
+    const asyncSum = asyncMode(sum);
+    const result = await asyncSum(2, 3);
+    expect(result).toBe(5);
+});
+
+test('asyncMode rejects on error', async () => {
+    const fail = () => { throw new Error('fail'); };
+    const asyncFail = asyncMode(fail);
+    await expect(asyncFail()).rejects.toThrow('fail');
+});


### PR DESCRIPTION
## Summary
- add unit tests for `asyncMode`
- document how to use `asyncMode`
- list Utils docs in API index

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_683bbea9713c8322a1754288265be600