### PR TITLE
Add TruncatedSVD algorithm

### DIFF
--- a/docs/content/docs/apis/decomposition/index.md
+++ b/docs/content/docs/apis/decomposition/index.md
@@ -4,3 +4,4 @@ description: API reference for Decomposition
 ---
 
 - [PCA](pca.md)
+- [TruncatedSVD](truncatedSVD.md)

--- a/docs/content/docs/apis/decomposition/truncatedSVD.md
+++ b/docs/content/docs/apis/decomposition/truncatedSVD.md
@@ -1,0 +1,29 @@
+---
+title: TruncatedSVD
+description: API reference for TruncatedSVD
+---
+
+# Decomposition.TruncatedSVD
+
+Dimensionality reduction using truncated Singular Value Decomposition of the data. Unlike PCA, the input data is not centered before decomposition.
+
+```ts
+constructor(nComponents: number = 2)
+```
+
+### Methods
+- `fit(X: number[][]): void`
+- `transform(X: number[][]): number[][]`
+- `fitTransform(X: number[][]): number[][]`
+- `inverseTransform(X: number[][]): number[][]`
+- `getComponents(): number[][]`
+- `getSingularValues(): number[]`
+- `getExplainedVariance(): number[]`
+- `getExplainedVarianceRatio(): number[]`
+
+### Example
+```ts
+const svd = new TruncatedSVD(2);
+svd.fit(X);
+const T = svd.transform(X_test);
+```

--- a/scripts/gen_all.py
+++ b/scripts/gen_all.py
@@ -22,6 +22,7 @@ scripts = [
     'gen_categorical_nb.py',
     'gen_svc.py',
     'gen_pca.py',
+    'gen_truncated_svd.py',
     'gen_spectral_embedding.py',
     'gen_mds.py',
     'gen_lle.py',

--- a/scripts/gen_truncated_svd.py
+++ b/scripts/gen_truncated_svd.py
@@ -1,0 +1,27 @@
+import numpy as np
+from sklearn.decomposition import TruncatedSVD
+from scipy.sparse import csr_matrix
+import json, os
+
+np.random.seed(0)
+X_dense = np.random.rand(100, 100)
+X_dense[:, 2 * np.arange(50)] = 0
+X = csr_matrix(X_dense)
+svd = TruncatedSVD(n_components=5, n_iter=7, random_state=42)
+svd.fit(X)
+X_test_dense = np.random.rand(10, 100)
+X_test_dense[:, 2 * np.arange(50)] = 0
+X_test = csr_matrix(X_test_dense)
+trans = svd.transform(X_test)
+
+os.makedirs('test_data', exist_ok=True)
+with open('test_data/truncated_svd.json', 'w') as f:
+    json.dump({
+        'X': X_dense.tolist(),
+        'X_test': X_test_dense.tolist(),
+        'expected': trans.tolist(),
+        'components': svd.components_.tolist(),
+        'explained_variance': svd.explained_variance_.tolist(),
+        'explained_variance_ratio': svd.explained_variance_ratio_.tolist(),
+        'singular_values': svd.singular_values_.tolist()
+    }, f)

--- a/scripts/gen_tsne.py
+++ b/scripts/gen_tsne.py
@@ -4,7 +4,7 @@ import json, os
 
 np.random.seed(0)
 X = np.random.randn(50, 4)
-model = TSNE(n_components=2, perplexity=20, n_iter=250, learning_rate=200, init='random', random_state=0, method='exact')
+model = TSNE(n_components=2, perplexity=20, max_iter=250, learning_rate=200, init='random', random_state=0, method='exact')
 Y = model.fit_transform(X)
 
 os.makedirs('test_data', exist_ok=True)

--- a/src/decomposition/__test__/truncatedSVD.compare.test.ts
+++ b/src/decomposition/__test__/truncatedSVD.compare.test.ts
@@ -1,0 +1,16 @@
+import { TruncatedSVD } from '../truncatedSVD';
+import fs from 'fs';
+import path from 'path';
+
+test('compare with sklearn', () => {
+    const p = path.join(__dirname, '../../../test_data/truncated_svd.json');
+    const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+    const svd = new TruncatedSVD(5);
+    svd.fit(data.X);
+    const pred = svd.transform(data.X_test);
+    for (let i = 0; i < pred.length; i++) {
+        for (let j = 0; j < pred[i].length; j++) {
+            expect(pred[i][j]).toBeCloseTo(data.expected[i][j], 1);
+        }
+    }
+});

--- a/src/decomposition/__test__/truncatedSVD.test.ts
+++ b/src/decomposition/__test__/truncatedSVD.test.ts
@@ -1,0 +1,20 @@
+import { TruncatedSVD } from '../truncatedSVD';
+
+test('basic truncated svd', () => {
+    const X = [
+        [1, 2, 3],
+        [4, 5, 9],
+        [7, 8, 15],
+        [2, 1, 3],
+        [3, 2, 5]
+    ];
+    const svd = new TruncatedSVD(2);
+    const T = svd.fitTransform(X);
+    expect(T.length).toBe(5);
+    const Xinv = svd.inverseTransform(T);
+    for (let i = 0; i < X.length; i++) {
+        for (let j = 0; j < X[i].length; j++) {
+            expect(Xinv[i][j]).toBeCloseTo(X[i][j], 0);
+        }
+    }
+});

--- a/src/decomposition/index.ts
+++ b/src/decomposition/index.ts
@@ -1,1 +1,2 @@
 export { PCA } from './pca';
+export { TruncatedSVD } from './truncatedSVD';

--- a/src/decomposition/truncatedSVD.ts
+++ b/src/decomposition/truncatedSVD.ts
@@ -1,0 +1,170 @@
+export class TruncatedSVD {
+    private nComponents: number;
+    private components: number[][];
+    private singularValues: number[];
+    private explainedVariance: number[];
+    private explainedVarianceRatio: number[];
+
+    constructor(nComponents: number = 2) {
+        this.nComponents = nComponents;
+        this.components = [];
+        this.singularValues = [];
+        this.explainedVariance = [];
+        this.explainedVarianceRatio = [];
+    }
+
+    private static dot(a: number[], b: number[]): number {
+        let s = 0;
+        for (let i = 0; i < a.length; i++) {
+            s += a[i] * b[i];
+        }
+        return s;
+    }
+
+    private static matVecMul(A: number[][], v: number[]): number[] {
+        return A.map(row => TruncatedSVD.dot(row, v));
+    }
+
+    private static outer(v1: number[], v2: number[]): number[][] {
+        const res: number[][] = [];
+        for (let i = 0; i < v1.length; i++) {
+            res.push([]);
+            for (let j = 0; j < v2.length; j++) {
+                res[i].push(v1[i] * v2[j]);
+            }
+        }
+        return res;
+    }
+
+    private static normalize(v: number[]): number[] {
+        const norm = Math.sqrt(TruncatedSVD.dot(v, v));
+        return v.map(x => x / norm);
+    }
+
+    private static powerIteration(A: number[][], iter: number = 100): { value: number; vector: number[] } {
+        let v: number[] = new Array(A.length).fill(1);
+        v = TruncatedSVD.normalize(v);
+        for (let i = 0; i < iter; i++) {
+            const Av = TruncatedSVD.matVecMul(A, v);
+            v = TruncatedSVD.normalize(Av);
+        }
+        const Av = TruncatedSVD.matVecMul(A, v);
+        const value = TruncatedSVD.dot(v, Av);
+        return { value, vector: v };
+    }
+
+    private static cloneMatrix(A: number[][]): number[][] {
+        return A.map(r => r.slice());
+    }
+
+    public fit(X: number[][]): void {
+        const nSamples = X.length;
+        const nFeatures = X[0].length;
+
+        const XtX: number[][] = [];
+        for (let i = 0; i < nFeatures; i++) {
+            XtX.push(new Array(nFeatures).fill(0));
+        }
+        for (let i = 0; i < nSamples; i++) {
+            for (let j = 0; j < nFeatures; j++) {
+                for (let k = 0; k < nFeatures; k++) {
+                    XtX[j][k] += X[i][j] * X[i][k];
+                }
+            }
+        }
+
+        const k = Math.min(this.nComponents, nFeatures);
+        let A = TruncatedSVD.cloneMatrix(XtX);
+        this.components = [];
+        this.singularValues = [];
+        this.explainedVariance = [];
+
+        for (let c = 0; c < k; c++) {
+            const { value, vector } = TruncatedSVD.powerIteration(A, 200);
+
+            let maxIdx = 0;
+            for (let i = 1; i < vector.length; i++) {
+                if (Math.abs(vector[i]) > Math.abs(vector[maxIdx])) {
+                    maxIdx = i;
+                }
+            }
+            if (vector[maxIdx] < 0) {
+                for (let i = 0; i < vector.length; i++) {
+                    vector[i] = -vector[i];
+                }
+            }
+
+            this.components.push(vector.slice());
+            const s = Math.sqrt(Math.max(value, 0));
+            this.singularValues.push(s);
+            this.explainedVariance.push((s * s) / (nSamples - 1));
+
+            const outer = TruncatedSVD.outer(vector, vector);
+            for (let i = 0; i < nFeatures; i++) {
+                for (let j = 0; j < nFeatures; j++) {
+                    A[i][j] -= value * outer[i][j];
+                }
+            }
+        }
+
+        const featureVar = new Array(nFeatures).fill(0);
+        const mean = new Array(nFeatures).fill(0);
+        for (let i = 0; i < nSamples; i++) {
+            for (let j = 0; j < nFeatures; j++) {
+                mean[j] += X[i][j];
+            }
+        }
+        for (let j = 0; j < nFeatures; j++) {
+            mean[j] /= nSamples;
+        }
+        for (let i = 0; i < nSamples; i++) {
+            for (let j = 0; j < nFeatures; j++) {
+                const diff = X[i][j] - mean[j];
+                featureVar[j] += diff * diff;
+            }
+        }
+        for (let j = 0; j < nFeatures; j++) {
+            featureVar[j] /= nSamples;
+        }
+        const totalVar = featureVar.reduce((a, b) => a + b, 0);
+
+        this.explainedVarianceRatio = this.explainedVariance.map(v => v / totalVar);
+    }
+
+    public transform(X: number[][]): number[][] {
+        return X.map(row => this.components.map(comp => TruncatedSVD.dot(row, comp)));
+    }
+
+    public fitTransform(X: number[][]): number[][] {
+        this.fit(X);
+        return this.transform(X);
+    }
+
+    public inverseTransform(X: number[][]): number[][] {
+        return X.map(row => {
+            const orig = new Array(this.components[0].length).fill(0);
+            for (let i = 0; i < this.components.length; i++) {
+                for (let j = 0; j < orig.length; j++) {
+                    orig[j] += this.components[i][j] * row[i];
+                }
+            }
+            return orig;
+        });
+    }
+
+    public getComponents(): number[][] {
+        return this.components;
+    }
+
+    public getSingularValues(): number[] {
+        return this.singularValues;
+    }
+
+    public getExplainedVariance(): number[] {
+        return this.explainedVariance;
+    }
+
+    public getExplainedVarianceRatio(): number[] {
+        return this.explainedVarianceRatio;
+    }
+}


### PR DESCRIPTION
## Summary
- implement TruncatedSVD
- generate test data with Python script
- export algorithm
- document API usage
- add unit tests
- fix TSNE data generator for sklearn 1.7
- adjust TruncatedSVD variance calculation

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6850608e63208322a9e9c4b95bca10e4