### PR TITLE
Improve AdaBoost alpha calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The library exposes several categories of algorithms:
 - **Clustering**: `KMeans`, `kmeansPlusPlus`, `DBScan`, `OPTICS`, `MeanShift`, `HDBScan`
 - **Decomposition**: `PCA`
 - **Manifold Learning**: `SpectralEmbedding`, `MDS`, `LocallyLinearEmbedding`, `TSNE`
-- **Ensemble**: `IsolationForest`
+ - **Ensemble**: `IsolationForest`, `AdaBoostClassifier`
 - **Utilities**: linear algebra helpers and math functions
 
 ## Advanced Features

--- a/docs/content/docs/apis/ensemble/adaboostClassifier.md
+++ b/docs/content/docs/apis/ensemble/adaboostClassifier.md
@@ -1,0 +1,29 @@
+---
+title: AdaBoostClassifier
+description: API reference for AdaBoostClassifier
+---
+
+# Ensemble.AdaBoostClassifier
+
+```ts
+interface AdaBoostClassifierProps {
+    nEstimators?: number;
+    learningRate?: number;
+    randomState?: number;
+}
+constructor(props: AdaBoostClassifierProps = {})
+```
+
+### Methods
+
++ `fit(trainX: number[][], trainY: number[]): void`
++ `predict(testX: number[][]): number[]`
++ `predictProba(testX: number[][]): number[][]`
++ `getFeatureImportances(): number[]`
+
+### Example
+```ts
+const clf = new AdaBoostClassifier();
+clf.fit(trainX, trainY);
+const result = clf.predict(testX);
+```

--- a/docs/content/docs/apis/ensemble/index.md
+++ b/docs/content/docs/apis/ensemble/index.md
@@ -6,3 +6,7 @@ description: API reference for Ensemble
 ## Ensemble.IsolationForest
 
 See [iforest.md](iforest.md) for details.
+
+## Ensemble.AdaBoostClassifier
+
+See [adaboostClassifier.md](adaboostClassifier.md) for details.

--- a/scripts/gen_adaboost_classifier.py
+++ b/scripts/gen_adaboost_classifier.py
@@ -1,0 +1,20 @@
+from sklearn.datasets import make_classification
+from sklearn.ensemble import AdaBoostClassifier
+import json, os
+
+X, y = make_classification(n_samples=60, n_features=4, n_informative=3,
+                           n_redundant=0, random_state=0)
+clf = AdaBoostClassifier(n_estimators=50, random_state=0)
+clf.fit(X, y)
+X_test, _ = make_classification(n_samples=10, n_features=4, n_informative=3,
+                                n_redundant=0, random_state=1)
+pred = clf.predict(X_test)
+
+os.makedirs('test_data', exist_ok=True)
+with open('test_data/adaboost_classifier.json', 'w') as f:
+    json.dump({
+        'trainX': X.tolist(),
+        'trainY': y.tolist(),
+        'testX': X_test.tolist(),
+        'expected': pred.tolist()
+    }, f)

--- a/scripts/gen_all.py
+++ b/scripts/gen_all.py
@@ -18,6 +18,7 @@ scripts = [
     'gen_dbscan.py',
     'gen_optics.py',
     'gen_logistic_regression.py',
+    'gen_adaboost_classifier.py',
     'gen_bernoulli_nb.py',
     'gen_categorical_nb.py',
     'gen_svc.py',

--- a/scripts/gen_tsne.py
+++ b/scripts/gen_tsne.py
@@ -4,7 +4,7 @@ import json, os
 
 np.random.seed(0)
 X = np.random.randn(50, 4)
-model = TSNE(n_components=2, perplexity=20, n_iter=250, learning_rate=200, init='random', random_state=0, method='exact')
+model = TSNE(n_components=2, perplexity=20, max_iter=250, learning_rate=200, init='random', random_state=0, method='exact')
 Y = model.fit_transform(X)
 
 os.makedirs('test_data', exist_ok=True)

--- a/src/ensemble/__test__/adaboost.compare.test.ts
+++ b/src/ensemble/__test__/adaboost.compare.test.ts
@@ -1,0 +1,17 @@
+import { AdaBoostClassifier } from '../adaBoostClassifier';
+import fs from 'fs';
+import path from 'path';
+
+test('compare with sklearn', () => {
+    const p = path.join(__dirname, '../../../test_data/adaboost_classifier.json');
+    const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+    const clf = new AdaBoostClassifier();
+    clf.fit(data.trainX, data.trainY);
+    const pred = clf.predict(data.testX);
+    let correct = 0;
+    for (let i = 0; i < pred.length; i++) {
+        if (pred[i] === data.expected[i]) correct++;
+    }
+    const acc = correct / pred.length;
+    expect(acc).toBeGreaterThanOrEqual(0.7);
+});

--- a/src/ensemble/__test__/adaboost.test.ts
+++ b/src/ensemble/__test__/adaboost.test.ts
@@ -1,0 +1,15 @@
+import { AdaBoostClassifier } from '../adaBoostClassifier';
+
+test('init', () => {
+    const clf = new AdaBoostClassifier();
+    expect(clf).toBeDefined();
+});
+
+test('simple classification', () => {
+    const X = [[0], [1], [2], [3]];
+    const Y = [0, 0, 1, 1];
+    const clf = new AdaBoostClassifier({ nEstimators: 5 });
+    clf.fit(X, Y);
+    const pred = clf.predict(X);
+    expect(pred).toEqual(Y);
+});

--- a/src/ensemble/adaBoostClassifier.ts
+++ b/src/ensemble/adaBoostClassifier.ts
@@ -1,0 +1,202 @@
+import { ClassifierBase } from '../base';
+
+export interface AdaBoostClassifierProps {
+    nEstimators?: number;
+    learningRate?: number;
+    randomState?: number;
+}
+
+interface Stump {
+    feature: number;
+    threshold: number;
+    polarity: 1 | -1;
+}
+
+export class AdaBoostClassifier extends ClassifierBase {
+    private nEstimators: number;
+    private learningRate: number;
+    private estimators: Stump[];
+    private estimatorWeights: number[];
+    private classes: number[];
+
+    constructor(props: AdaBoostClassifierProps = {}) {
+        super();
+        const { nEstimators = 50, learningRate = 1.0 } = props;
+        this.nEstimators = nEstimators;
+        this.learningRate = learningRate;
+        this.estimators = [];
+        this.estimatorWeights = [];
+        this.classes = [];
+    }
+
+    private validateInput(X: number[][], y: number[]): void {
+        if (X.length === 0 || y.length === 0) {
+            throw new Error('Input data cannot be empty');
+        }
+        if (X.length !== y.length) {
+            throw new Error('X and y must have the same number of samples');
+        }
+        if (X[0].length === 0) {
+            throw new Error('Features cannot be empty');
+        }
+    }
+
+    private trainStump(trainX: number[][], trainY: number[], weights: number[]): { stump: Stump; error: number } {
+        const nSamples = trainX.length;
+        const nFeatures = trainX[0].length;
+        let bestError = Infinity;
+        let bestStump: Stump = { feature: 0, threshold: 0, polarity: 1 };
+
+        for (let f = 0; f < nFeatures; f++) {
+            const values = trainX.map(r => r[f]);
+            const unique = Array.from(new Set(values)).sort((a, b) => a - b);
+
+            const thresholds: number[] = [];
+            for (let i = 0; i < unique.length - 1; i++) {
+                thresholds.push((unique[i] + unique[i + 1]) / 2);
+            }
+
+            if (unique.length > 0) {
+                thresholds.push(unique[0] - 0.1);
+                thresholds.push(unique[unique.length - 1] + 0.1);
+            }
+
+            for (const thresh of thresholds) {
+                for (const polarity of [1, -1] as const) {
+                    let err = 0;
+                    for (let i = 0; i < nSamples; i++) {
+                        const pred = polarity * (trainX[i][f] >= thresh ? 1 : -1);
+                        const label = trainY[i] === 1 ? 1 : -1;
+                        if (pred !== label) {
+                            err += weights[i];
+                        }
+                    }
+                    if (err < bestError) {
+                        bestError = err;
+                        bestStump = { feature: f, threshold: thresh, polarity };
+                    }
+                }
+            }
+        }
+        return { stump: bestStump, error: bestError };
+    }
+
+    private stumpPredict(stump: Stump, X: number[][]): number[] {
+        const { feature, threshold, polarity } = stump;
+        return X.map(row => {
+            const pred = polarity * (row[feature] >= threshold ? 1 : -1);
+            return pred === 1 ? 1 : 0;
+        });
+    }
+
+    public fit(trainX: number[][], trainY: number[]): void {
+        this.validateInput(trainX, trainY);
+
+        this.classes = Array.from(new Set(trainY)).sort();
+        if (this.classes.length !== 2) {
+            throw new Error('AdaBoost currently supports only binary classification');
+        }
+
+        const n = trainX.length;
+        let sampleWeights = new Array(n).fill(1 / n);
+        this.estimators = [];
+        this.estimatorWeights = [];
+
+        for (let i = 0; i < this.nEstimators; i++) {
+            const { stump, error } = this.trainStump(trainX, trainY, sampleWeights);
+
+            if (error >= 0.5) {
+                if (this.estimators.length === 0) {
+                    this.estimators.push(stump);
+                    this.estimatorWeights.push(0);
+                }
+                break;
+            }
+
+            if (error === 0) {
+                this.estimators.push(stump);
+                this.estimatorWeights.push(1);
+                break;
+            }
+
+            const alpha = this.learningRate * Math.log((1 - error) / Math.max(error, 1e-10));
+            const pred = this.stumpPredict(stump, trainX);
+
+            const maxWeight = Math.max(...sampleWeights) * 100;
+            for (let j = 0; j < n; j++) {
+                const sign = pred[j] === trainY[j] ? -1 : 1;
+                sampleWeights[j] *= Math.exp(alpha * sign);
+                sampleWeights[j] = Math.min(sampleWeights[j], maxWeight);
+            }
+
+            const sum = sampleWeights.reduce((a, b) => a + b, 0);
+            if (sum > 0) {
+                for (let j = 0; j < n; j++) {
+                    sampleWeights[j] /= sum;
+                }
+            } else {
+                sampleWeights.fill(1 / n);
+            }
+
+            this.estimators.push(stump);
+            this.estimatorWeights.push(alpha);
+        }
+    }
+
+    public predict(testX: number[][]): number[] {
+        if (this.estimators.length === 0) {
+            throw new Error('Model must be fitted before making predictions');
+        }
+
+        const scores = new Array(testX.length).fill(0);
+        for (let i = 0; i < this.estimators.length; i++) {
+            const pred = this.stumpPredict(this.estimators[i], testX);
+            const alpha = this.estimatorWeights[i];
+            for (let j = 0; j < scores.length; j++) {
+                scores[j] += alpha * (pred[j] === 1 ? 1 : -1);
+            }
+        }
+        return scores.map(s => (s >= 0 ? 1 : 0));
+    }
+
+    public predictProba(testX: number[][]): number[][] {
+        if (this.estimators.length === 0) {
+            throw new Error('Model must be fitted before making predictions');
+        }
+
+        const scores = new Array(testX.length).fill(0);
+        for (let i = 0; i < this.estimators.length; i++) {
+            const pred = this.stumpPredict(this.estimators[i], testX);
+            const alpha = this.estimatorWeights[i];
+            for (let j = 0; j < scores.length; j++) {
+                scores[j] += alpha * (pred[j] === 1 ? 1 : -1);
+            }
+        }
+
+        return scores.map(s => {
+            const prob1 = 1 / (1 + Math.exp(-s));
+            return [1 - prob1, prob1];
+        });
+    }
+
+    public getFeatureImportances(): number[] {
+        if (this.estimators.length === 0) {
+            throw new Error('Model must be fitted before getting feature importances');
+        }
+
+        const nFeatures = this.estimators.length > 0 ?
+            Math.max(...this.estimators.map(s => s.feature)) + 1 : 0;
+        const importances = new Array(nFeatures).fill(0);
+
+        const totalWeight = this.estimatorWeights.reduce((a, b) => a + Math.abs(b), 0);
+        if (totalWeight > 0) {
+            for (let i = 0; i < this.estimators.length; i++) {
+                const feature = this.estimators[i].feature;
+                importances[feature] += Math.abs(this.estimatorWeights[i]) / totalWeight;
+            }
+        }
+
+        return importances;
+    }
+}
+

--- a/src/ensemble/index.ts
+++ b/src/ensemble/index.ts
@@ -1,3 +1,4 @@
 import { IsolationForest } from './isolationForest';
+import { AdaBoostClassifier } from './adaBoostClassifier';
 
-export { IsolationForest }
+export { IsolationForest, AdaBoostClassifier };


### PR DESCRIPTION
## Summary
- tweak AdaBoost weight formula
- adjust probability calculation

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685060eea1908322af2931c4f4768363