### PR TITLE
Improve decomposition docs

### DIFF
--- a/docs/content/docs/apis/decomposition/index.md
+++ b/docs/content/docs/apis/decomposition/index.md
@@ -3,6 +3,6 @@ title: Decomposition
 description: API reference for Decomposition
 ---
 
-- [PCA](pca.md)
-- [TruncatedSVD](truncatedSVD.md)
-- [SparsePCA](sparsePCA.md)
+- [PCA](pca)
+- [TruncatedSVD](truncatedSVD)
+- [SparsePCA](sparsePCA)

--- a/docs/content/docs/apis/decomposition/pca.md
+++ b/docs/content/docs/apis/decomposition/pca.md
@@ -7,9 +7,16 @@ description: API reference for PCA
 
 Linear dimensionality reduction using Singular Value Decomposition of the data to project it to a lower dimensional space. The input data is centered but not scaled for each feature before applying the SVD.
 
+### Algorithm
+The covariance matrix of the centered samples is decomposed by power iteration.
+The resulting eigenvectors form the principal components sorted by explained variance.
+
 ```ts
 constructor(nComponents: number | null = null)
 ```
+
+### Parameters
+- `nComponents` (number | null, default `null`): number of principal components to retain. If `null`, all components are used.
 
 ### Methods
 - `fit(X: number[][]): void`

--- a/docs/content/docs/apis/decomposition/sparsePCA.md
+++ b/docs/content/docs/apis/decomposition/sparsePCA.md
@@ -7,6 +7,10 @@ description: API reference for SparsePCA
 
 Sparse Principal Components Analysis using truncated power iteration with soft thresholding. The algorithm stops when the updates change by less than `tol` or when `maxIter` is reached.
 
+### Algorithm
+Each component is extracted by iterative thresholding of the covariance matrix.
+The process encourages sparsity by shrinking small coefficients towards zero.
+
 ```ts
 interface SparsePCAProps {
     nComponents?: number | null;
@@ -16,6 +20,12 @@ interface SparsePCAProps {
 }
 constructor(props: SparsePCAProps = {})
 ```
+
+### Parameters
+- `nComponents` (number | null, default `null`): number of sparse components to compute. `null` keeps all components.
+- `alpha` (number, default `1`): sparsity controlling parameter. Higher values lead to more zero coefficients.
+- `maxIter` (number, default `100`): maximum number of iterations for each component.
+- `tol` (number, default `1e-8`): stopping criterion for convergence of the iterative updates.
 
 ### Example
 ```ts

--- a/docs/content/docs/apis/decomposition/truncatedSVD.md
+++ b/docs/content/docs/apis/decomposition/truncatedSVD.md
@@ -7,9 +7,15 @@ description: API reference for TruncatedSVD
 
 Dimensionality reduction using truncated Singular Value Decomposition of the data. Unlike PCA, the input data is not centered before decomposition.
 
+### Algorithm
+The algorithm performs power iteration on the uncentered covariance matrix and keeps the top components corresponding to the largest singular values.
+
 ```ts
 constructor(nComponents: number = 2)
 ```
+
+### Parameters
+- `nComponents` (number, default `2`): number of singular vectors to retain.
 
 ### Methods
 - `fit(X: number[][]): void`


### PR DESCRIPTION
## Summary
- fix decomposition page links
- expand docs for PCA, SparsePCA and TruncatedSVD

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6850d857f3588322a5fd97c91661eaec