### PR TITLE
Improve SVM API docs

### DIFF
--- a/docs/content/docs/apis/svm/LinearSVC.md
+++ b/docs/content/docs/apis/svm/LinearSVC.md
@@ -5,6 +5,8 @@ description: API reference for LinearSVC
 
 # SVM.LinearSVC
 
+Linear support vector classifier optimized with gradient descent on hinge loss. It trains one-versus-rest linear models to separate classes.
+
 ```ts
 interface LinearSVCProps {
     C?: number;
@@ -13,6 +15,11 @@ interface LinearSVCProps {
 }
 constructor(props: LinearSVCProps = {})
 ```
+
+### Parameters
+- `C` (number, default `1`): regularization strength
+- `maxIter` (number, default `100`): maximum training iterations
+- `learningRate` (number, default `0.01`): step size for gradient descent
 
 ### Example
 ```ts

--- a/docs/content/docs/apis/svm/NuSVC.md
+++ b/docs/content/docs/apis/svm/NuSVC.md
@@ -5,11 +5,21 @@ description: API reference for NuSVC
 
 # SVM.NuSVC
 
+Variant of `SVC` that uses the `nu` parameter to control the fraction of support vectors and the margin errors.
+
 ```ts
 interface NuSVCProps {
     nu?: number;
 }
 constructor(props: NuSVCProps = {})
 ```
+
+### Parameters
+- `nu` (number, default `0.5`): trade-off between the number of support vectors and training errors
+- `C` (number, default `1/nu`): regularization strength
+- `maxIter` (number, default `100`): maximum iterations for training
+- `learningRate` (number, default `0.01`): step size for gradient descent
+- `kernel` ('linear' | 'rbf', default `'rbf'`): kernel type
+- `gamma` (number, default `1`): RBF kernel coefficient
 
 NuSVC shares the same usage as `SVC` but uses the `nu` parameter instead of `C`.

--- a/docs/content/docs/apis/svm/SVC.md
+++ b/docs/content/docs/apis/svm/SVC.md
@@ -5,6 +5,8 @@ description: API reference for SVC
 
 # SVM.SVC
 
+Support Vector Classification. When the kernel is set to `rbf` it applies the kernel trick to transform input features before training a linear classifier.
+
 ```ts
 interface SVCProps {
     C?: number;
@@ -15,6 +17,13 @@ interface SVCProps {
 }
 constructor(props: SVCProps = {})
 ```
+
+### Parameters
+- `C` (number, default `1`): regularization strength
+- `maxIter` (number, default `100`): maximum iterations for training
+- `learningRate` (number, default `0.01`): step size for the optimizer
+- `kernel` ('linear' | 'rbf', default `'rbf'`): kernel type
+- `gamma` (number, default `1`): RBF kernel coefficient
 
 ### Example
 ```ts

--- a/docs/content/docs/apis/svm/index.md
+++ b/docs/content/docs/apis/svm/index.md
@@ -3,6 +3,6 @@ title: SVM
 description: API reference for SVM
 ---
 
-- [SVC](SVC.md)
-- [NuSVC](NuSVC.md)
-- [LinearSVC](LinearSVC.md)
+- [SVC](SVC)
+- [NuSVC](NuSVC)
+- [LinearSVC](LinearSVC)


### PR DESCRIPTION
## Summary
- fix SVM docs navigation links
- expand SVM algorithm docs with explanations and parameter details

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6850d8d255448322ba5b6e16ca05ef81