### PR TITLE
Improve linear docs

### DIFF
--- a/docs/content/docs/apis/linear/index.md
+++ b/docs/content/docs/apis/linear/index.md
@@ -3,5 +3,5 @@ title: Linear
 description: API reference for Linear
 ---
 
-- [LinearRegression](linearRegression.md)
-- [LogisticRegression](logisticRegression.md)
+- [LinearRegression](linearRegression)
+- [LogisticRegression](logisticRegression)

--- a/docs/content/docs/apis/linear/linearRegression.md
+++ b/docs/content/docs/apis/linear/linearRegression.md
@@ -9,9 +9,20 @@ description: API reference for LinearRegression
 constructor()
 ```
 
+This class implements ordinary least squares linear regression. It estimates
+coefficients for a linear model by minimizing the squared error between
+predicted and actual values.
+
 ### Methods
 + `fit(X: number[][], Y: number[]): void`
 + `predict(X: number[][]): number[]`
+
+#### fit
+* `X` - Feature matrix of shape `[nSamples, nFeatures]`.
+* `Y` - Target values of length `nSamples`.
+
+#### predict
+* `X` - Feature matrix for which to compute predictions.
 
 ### Example
 ```ts

--- a/docs/content/docs/apis/linear/logisticRegression.md
+++ b/docs/content/docs/apis/linear/logisticRegression.md
@@ -13,6 +13,21 @@ interface LogisticRegressionProps {
 constructor(props: LogisticRegressionProps = {})
 ```
 
+Performs binary logistic regression optimized with gradient descent. The
+`learningRate` controls the step size during optimization and `maxIter`
+specifies the number of iterations.
+
+### Methods
+* `fit(trainX: number[][], trainY: number[]): void`
+* `predict(testX: number[][]): number[]`
+
+#### fit
+* `trainX` - Training features with shape `[nSamples, nFeatures]`.
+* `trainY` - Binary labels for each training sample.
+
+#### predict
+* `testX` - Feature matrix to classify.
+
 ### Example
 ```ts
 const clf = new LogisticRegression();


### PR DESCRIPTION
## Summary
- fix broken links for linear API pages
- document LinearRegression parameters and usage
- document LogisticRegression parameters and usage

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6850d891a0808322b9ae7d93bc306cf3