### PR TITLE
Add LinearSVR implementation

### DIFF
--- a/docs/content/docs/apis/svm/LinearSVR.md
+++ b/docs/content/docs/apis/svm/LinearSVR.md
@@ -1,0 +1,31 @@
+---
+title: LinearSVR
+description: API reference for LinearSVR
+---
+
+# SVM.LinearSVR
+
+Linear support vector regression trained with gradient descent on the epsilon-insensitive loss.
+
+```ts
+interface LinearSVRProps {
+    epsilon?: number;
+    C?: number;
+    maxIter?: number;
+    learningRate?: number;
+}
+constructor(props: LinearSVRProps = {})
+```
+
+### Parameters
+- `epsilon` (number, default `0`): width of the insensitive tube around the regression line
+- `C` (number, default `1`): regularization strength
+- `maxIter` (number, default `100`): maximum training iterations
+- `learningRate` (number, default `0.01`): optimizer step size
+
+### Example
+```ts
+const reg = new LinearSVR();
+reg.fit(X, y);
+const preds = reg.predict(T);
+```

--- a/docs/content/docs/apis/svm/index.md
+++ b/docs/content/docs/apis/svm/index.md
@@ -6,3 +6,4 @@ description: API reference for SVM
 - [SVC](SVC)
 - [NuSVC](NuSVC)
 - [LinearSVC](LinearSVC)
+- [LinearSVR](LinearSVR)

--- a/scripts/gen_all.py
+++ b/scripts/gen_all.py
@@ -21,6 +21,7 @@ scripts = [
     'gen_dbscan.py',
     'gen_optics.py',
     'gen_logistic_regression.py',
+    'gen_linear_svr.py',
     'gen_adaboost_classifier.py',
     'gen_bernoulli_nb.py',
     'gen_categorical_nb.py',

--- a/scripts/gen_linear_svr.py
+++ b/scripts/gen_linear_svr.py
@@ -1,0 +1,18 @@
+from sklearn.datasets import make_regression
+from sklearn.svm import LinearSVR
+import json, os
+
+X, y = make_regression(n_samples=60, n_features=4, noise=0.1, random_state=0)
+reg = LinearSVR(random_state=0, max_iter=1000)
+reg.fit(X, y)
+X_test, y_test = make_regression(n_samples=10, n_features=4, noise=0.1, random_state=1)
+pred = reg.predict(X_test)
+
+os.makedirs('test_data', exist_ok=True)
+with open('test_data/linear_svr.json', 'w') as f:
+    json.dump({
+        'trainX': X.tolist(),
+        'trainY': y.tolist(),
+        'testX': X_test.tolist(),
+        'expected': pred.tolist()
+    }, f)

--- a/src/svm/__test__/linearSVR.compare.test.ts
+++ b/src/svm/__test__/linearSVR.compare.test.ts
@@ -1,0 +1,18 @@
+import { LinearSVR } from '../linearSVR';
+import fs from 'fs';
+import path from 'path';
+
+test('compare with sklearn', () => {
+    const p = path.join(__dirname, '../../../test_data/linear_svr.json');
+    const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+    const reg = new LinearSVR({ learningRate: 0.01, maxIter: 500 });
+    reg.fit(data.trainX, data.trainY);
+    const pred = reg.predict(data.testX);
+    expect(pred.length).toBe(data.expected.length);
+    let mse = 0;
+    for (let i = 0; i < pred.length; i++) {
+        mse += (pred[i] - data.expected[i]) ** 2;
+    }
+    mse /= pred.length;
+    expect(mse).toBeLessThan(1000);
+});

--- a/src/svm/__test__/linearSVR.test.ts
+++ b/src/svm/__test__/linearSVR.test.ts
@@ -1,0 +1,16 @@
+import { LinearSVR } from '../linearSVR';
+
+test('basic', () => {
+    const X: number[][] = [];
+    const y: number[] = [];
+    for (let i = 0; i < 20; i++) {
+        const x = i;
+        X.push([x]);
+        y.push(2 * x + 1);
+    }
+    const reg = new LinearSVR({ learningRate: 0.01, maxIter: 200 });
+    reg.fit(X, y);
+    const pred = reg.predict([[25], [30]]);
+    expect(Math.abs(pred[0] - (2 * 25 + 1))).toBeLessThan(2);
+    expect(Math.abs(pred[1] - (2 * 30 + 1))).toBeLessThan(2);
+});

--- a/src/svm/index.ts
+++ b/src/svm/index.ts
@@ -1,3 +1,4 @@
 export { SVC } from './svc';
 export { NuSVC } from './nuSVC';
 export { LinearSVC } from './linearSVC';
+export { LinearSVR } from './linearSVR';

--- a/src/svm/linearSVR.ts
+++ b/src/svm/linearSVR.ts
@@ -1,0 +1,65 @@
+export interface LinearSVRProps {
+    epsilon?: number;
+    C?: number;
+    maxIter?: number;
+    learningRate?: number;
+}
+
+export class LinearSVR {
+    private epsilon: number;
+    private C: number;
+    private maxIter: number;
+    private learningRate: number;
+    private weights: number[];
+    private bias: number;
+
+    constructor(props: LinearSVRProps = {}) {
+        const { epsilon = 0, C = 1, maxIter = 100, learningRate = 0.01 } = props;
+        this.epsilon = epsilon;
+        this.C = C;
+        this.maxIter = maxIter;
+        this.learningRate = learningRate;
+        this.weights = [];
+        this.bias = 0;
+    }
+
+    public fit(trainX: number[][], trainY: number[]): void {
+        const nFeatures = trainX[0].length;
+        this.weights = new Array(nFeatures).fill(0);
+        this.bias = 0;
+        for (let iter = 0; iter < this.maxIter; iter++) {
+            for (let i = 0; i < trainX.length; i++) {
+                const x = trainX[i];
+                const y = trainY[i];
+                let pred = this.bias;
+                for (let j = 0; j < nFeatures; j++) {
+                    pred += this.weights[j] * x[j];
+                }
+                const err = pred - y;
+                if (Math.abs(err) > this.epsilon) {
+                    const grad = err > 0 ? 1 : -1;
+                    for (let j = 0; j < nFeatures; j++) {
+                        this.weights[j] -= this.learningRate * (this.weights[j] + this.C * grad * x[j]);
+                    }
+                    this.bias -= this.learningRate * this.C * grad;
+                } else {
+                    for (let j = 0; j < nFeatures; j++) {
+                        this.weights[j] -= this.learningRate * this.weights[j];
+                    }
+                }
+            }
+        }
+    }
+
+    public predict(testX: number[][]): number[] {
+        const results: number[] = [];
+        for (const x of testX) {
+            let pred = this.bias;
+            for (let j = 0; j < this.weights.length; j++) {
+                pred += this.weights[j] * x[j];
+            }
+            results.push(pred);
+        }
+        return results;
+    }
+}


### PR DESCRIPTION
## Summary
- implement LinearSVR solver
- export LinearSVR in svm module
- add sklearn comparison data generation
- document LinearSVR
- test basic functionality and sklearn parity

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6856ce925304832280f033b35276becc