### PR TITLE
Fix canonical metadata for docs and improve K-Means SEO

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import {
 import { notFound } from 'next/navigation';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { getMDXComponents } from '@/mdx-components';
+import type { Metadata } from 'next';
 
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
@@ -40,13 +41,21 @@ export async function generateStaticParams() {
 
 export async function generateMetadata(props: {
   params: Promise<{ slug?: string[] }>;
-}) {
+}): Promise<Metadata> {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
+  const slug = params.slug ?? [];
+  const path = slug.length ? `/docs/${slug.join('/')}` : '/docs';
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://kanaries.net';
+  const canonicalUrl = new URL(path, siteUrl).toString();
+
   return {
     title: page.data.title,
     description: page.data.description,
+    alternates: {
+      canonical: canonicalUrl,
+    },
   };
 }

--- a/docs/content/docs/apis/clusters/kmeans.md
+++ b/docs/content/docs/apis/clusters/kmeans.md
@@ -1,9 +1,11 @@
 ---
-title: KMeans
-description: API reference for KMeans
+title: K-Means Clustering (KMeans) – @kanaries/ml Algorithm Guide
+description: Learn how to apply the K-Means clustering algorithm with @kanaries/ml, including parameter definitions, TypeScript API usage, and examples for segmenting datasets in modern web apps.
 ---
 
-# Clusters.KMeans
+# K-Means Clustering (Clusters.KMeans)
+
+K-Means clustering partitions datasets into a chosen number of groups by minimizing within-cluster variance. Use the `Clusters.KMeans` implementation in @kanaries/ml to build fast, client-side segmentation pipelines for browser or Node.js applications.
 
 ```ts
 constructor (n_clusters: number = 2, opt_ratio: number = 0.05, initCenters?: number[][], max_iter: number = 30)


### PR DESCRIPTION
## Summary
- add canonical URL generation to documentation metadata with support for environment overrides
- refine the K-Means clustering guide title, description, and introduction copy for improved search relevance

## Testing
- yarn --cwd docs install *(fails: registry responded with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c904d40aa08322b1ff4a6d8ad85851