### PR TITLE
docs: refactor documentation homepage and seo plan

### DIFF
--- a/docs/SEO_PLAN.md
+++ b/docs/SEO_PLAN.md
@@ -1,0 +1,46 @@
+# Documentation SEO Optimization Plan
+
+## Objectives
+- Improve visibility of the ml documentation for machine learning in JavaScript and TypeScript searches.
+- Increase engagement metrics by providing deeper explanations, examples, and internal navigation.
+- Ensure each documentation page exposes descriptive meta titles and summaries that highlight key capabilities.
+
+## Target Keywords
+- "JavaScript machine learning library"
+- "TypeScript machine learning API"
+- "browser-based machine learning"
+- "JavaScript data science toolkit"
+- "@kanaries/ml documentation"
+- "isolation forest JavaScript"
+- "JavaScript anomaly detection"
+- "train machine learning model in the browser"
+
+## Priority Pages
+1. **Documentation Home (`docs/content/docs/index.mdx`)**
+   - Restructure the hero, value proposition, and navigation to surface primary learning paths.
+   - Add scannable feature highlights, quick start workflow, and links to popular guides for stronger engagement.
+   - Update metadata and headings with primary keywords such as "JavaScript machine learning" and "browser ML tutorials".
+2. **Getting Started (`docs/content/docs/getting-started.mdx` when introduced)**
+   - Spin off detailed onboarding steps from the home page into a dedicated guide to support deeper keyword targeting.
+   - Include end-to-end workflow examples, troubleshooting tips, and links to API modules.
+3. **API References (`docs/content/docs/apis/index.md`)**
+   - Provide overview of available modules with keyword-rich descriptions.
+   - Introduce internal links and context for each algorithm group.
+   - Update meta title/description to emphasize JavaScript/TypeScript ML APIs.
+4. **Ensemble Module (`docs/content/docs/apis/ensemble/index.md`)**
+   - Replace terse references with explanations of each estimator, expected use cases, and configuration notes.
+   - Optimize headers for long-tail queries (e.g., "Isolation Forest anomaly detection in JavaScript").
+
+## Execution Steps
+1. **Audit Content** – Review existing structure and identify missing details for priority pages.
+2. **Enhance Metadata** – Rewrite titles and descriptions to include high-value keywords.
+3. **Expand Content** – Add explanatory text, bullet lists, tables, and cross-links to deepen engagement.
+4. **Refactor Navigation** – Consolidate duplicate content, promote popular entry points, and ensure the homepage funnels visitors to top tasks.
+5. **Review Internal Linking** – Ensure related docs are linked to encourage navigation across the site.
+6. **Quality Check** – Run documentation build/tests (if applicable) and proofread for clarity.
+
+## Success Metrics
+- Increased organic impressions for targeted keywords (tracked via analytics tools).
+- Longer average session duration on documentation pages.
+- Higher click-through rates from search results due to compelling meta information.
+

--- a/docs/content/docs/apis/ensemble/index.md
+++ b/docs/content/docs/apis/ensemble/index.md
@@ -1,16 +1,50 @@
 ---
-title: Ensemble
-description: API reference for Ensemble
+title: Ensemble Algorithms in @kanaries/ml
+description: Detailed API reference for Isolation Forest and AdaBoost ensemble learning algorithms in JavaScript and TypeScript.
 ---
 
-## Ensemble.IsolationForest
+# Ensemble algorithms
 
-See [iforest](iforest) for details.
+Ensemble methods in @kanaries/ml combine multiple weak learners to produce stronger, more resilient models for both regression and classification tasks. Use the links below to explore parameter definitions, method signatures, and implementation details for each estimator.
 
-## Ensemble.AdaBoostRegressor
+## Isolation Forest for anomaly detection
 
-See [adaboost](adaboost) for details.
+`Ensemble.IsolationForest` isolates anomalies by randomly partitioning the feature space. Shorter average path lengths indicate outliers, making this algorithm well-suited for fraud detection, observability metrics, and IoT monitoring in JavaScript environments.
 
-## Ensemble.AdaBoostClassifier
+**Highlights**
 
-See [adaboostClassifier](adaboostClassifier) for details.
+- Works with high-dimensional tabular data without heavy preprocessing.
+- Offers configurable contamination rates to tune sensitivity.
+- Runs in browsers or Node.js with minimal dependencies.
+
+[Read the full Isolation Forest API reference](iforest.md) for constructor arguments, fit/predict usage, and scoring helpers.
+
+## AdaBoostRegressor for gradient boosting
+
+`Ensemble.AdaBoostRegressor` sequentially trains weak regressors and boosts their contributions to reduce error. It is ideal for modeling continuous targets where interpretability and responsiveness matter.
+
+**Use cases**
+
+- Forecasting metrics for product analytics dashboards.
+- Enhancing baseline linear models with non-linear corrections.
+- Building lightweight regressors that deploy quickly in serverless functions.
+
+[Review the AdaBoost regressor documentation](adaboost.md) for hyperparameters and example workflows.
+
+## AdaBoostClassifier for robust classification
+
+`Ensemble.AdaBoostClassifier` focuses on misclassified samples in each iteration to improve predictive accuracy. Apply it to click-through rate prediction, churn modeling, or any binary/multi-class problem where you need fast inference in JavaScript.
+
+**Key capabilities**
+
+- Adjustable learning rates to balance speed and generalization.
+- Support for sample weighting and class imbalance handling.
+- Compatible with the preprocessing tools found in the [utils module](../utils/index.md).
+
+[Explore the AdaBoost classifier guide](adaboostClassifier.md) for parameter tables, training instructions, and evaluation tips.
+
+## Related resources
+
+- Return to the [API overview](../index.md) to browse additional algorithm families.
+- Follow the [Getting Started tutorial](../../index.mdx) to integrate ensembles into a new project.
+- Experiment with datasets in the [`examples` folder](../../../../../examples) to see ensemble models in action.

--- a/docs/content/docs/apis/index.md
+++ b/docs/content/docs/apis/index.md
@@ -1,19 +1,23 @@
 ---
-title: API References
-description: Machine learning API documentation
+title: JavaScript Machine Learning API Reference
+description: Explore the @kanaries/ml API for clustering, classification, anomaly detection, and more in JavaScript and TypeScript.
 ---
 
-# API References
+# @kanaries/ml API Reference
 
-- [Clusters](clusters/index.md)
-- [Decomposition](decomposition/index.md)
-- [Ensemble](ensemble/index.md)
-- [Linear](linear/index.md)
-- [Manifold](manifold/index.md)
-- [Neighbors](neighbors/index.md)
-- [SVM](svm/index.md)
-- [Tree](tree/index.md)
-- [Bayes](bayes/index.md)
-- [NeuralNetwork](neural_network/index.md)
-- [Utils](utils/index.md)
-- [SemiSupervised](semi_supervised/index.md)
+This catalog describes every module available in @kanaries/ml so you can quickly locate the algorithm or utility that fits your JavaScript or TypeScript project. Each section below links to a detailed page covering parameters, usage patterns, and practical tips.
+
+- **[Clusters](clusters/index.md)** – Implement k-means, DBSCAN, spectral clustering, and other unsupervised techniques for segmentation and feature discovery.
+- **[Decomposition](decomposition/index.md)** – Run dimensionality reduction methods such as PCA and SVD directly in the browser or Node.js.
+- **[Ensemble](ensemble/index.md)** – Combine multiple estimators including Isolation Forest and AdaBoost for robust anomaly detection and boosting workflows.
+- **[Linear](linear/index.md)** – Access regression and classification algorithms like Linear Regression, Lasso, and Logistic Regression with sklearn-like APIs.
+- **[Manifold](manifold/index.md)** – Visualize high-dimensional data using t-SNE, Isomap, and related manifold learning approaches.
+- **[Neighbors](neighbors/index.md)** – Use k-nearest neighbors for search, recommendation, and classification tasks.
+- **[SVM](svm/index.md)** – Train support vector machines for high-margin classification and regression scenarios.
+- **[Tree](tree/index.md)** – Build decision trees and random forests for interpretable models and tabular data analysis.
+- **[Bayes](bayes/index.md)** – Apply naive Bayes and probabilistic models to text classification, spam detection, and more.
+- **[NeuralNetwork](neural_network/index.md)** – Prototype lightweight neural networks tailored for in-browser inference.
+- **[Utils](utils/index.md)** – Leverage preprocessing helpers, metrics, and shared utilities to streamline your ML pipelines.
+- **[SemiSupervised](semi_supervised/index.md)** – Combine labeled and unlabeled data to boost performance in low-label environments.
+
+Looking for inspiration? The [Getting Started guide](../index.mdx) and [examples directory](../../../../examples) provide end-to-end workflows you can adapt for your application.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,29 +1,74 @@
 ---
-title: Getting Started
-description: Getting Started with ml
+title: Build JavaScript Machine Learning with @kanaries/ml
+description: Discover how to train and deploy machine learning models in JavaScript and TypeScript using @kanaries/ml, including installation, core features, tutorials, and API references.
 ---
 
-# Getting Started
+# Build machine learning in JavaScript with @kanaries/ml
 
-## Install
-![](https://img.shields.io/github/license/kanaries/ml?)
-![](https://img.shields.io/npm/v/@kanaries/ml?)
-```bash
-npm i --save @kanaries/ml
-```
+@kanaries/ml delivers scikit-learn inspired tooling for JavaScript and TypeScript so you can prototype, train, and deploy machine learning models in the browser or on Node.js services. Use this home page as your launchpad for installation steps, guided tutorials, and deep-dive API references.
 
-## Usage
+## Start here
+
+1. **Install the SDK** – Add the package with your preferred manager. Both builds include TypeScript definitions out of the box.
+
+   ```bash
+   npm install @kanaries/ml
+   ```
+
+   ```bash
+   yarn add @kanaries/ml
+   ```
+
+2. **Explore quickstart recipes** – Follow the [anomaly detection walkthrough](#build-an-anomaly-detector) or jump straight to the [API catalog](apis/index.md) to browse available estimators.
+3. **Integrate with your stack** – Pair @kanaries/ml with modern frameworks, dashboards, and serverless runtimes to deliver on-device intelligence without round-trips to Python services.
+
+## Why teams choose @kanaries/ml
+
+- **Built for browsers and Node.js** – Run classical ML workflows alongside your UI code or in lightweight edge functions.
+- **Type-safe developer experience** – Strong typings and predictable method signatures accelerate onboarding for TypeScript teams.
+- **Comprehensive algorithm coverage** – Access clustering, decomposition, ensembles, linear models, neural networks, and more through a consistent API surface.
+- **Interoperable with Python tooling** – Mirror familiar scikit-learn patterns to translate notebooks into production-ready JavaScript apps.
+
+## Build an anomaly detector
 
 ```typescript
-import { Ensemble } from '@kanaries';
+import { Ensemble } from '@kanaries/ml';
 
-const iForest = new Ensemble.IsolationForest();
+const isolationForest = new Ensemble.IsolationForest({
+  nEstimators: 100,
+  contamination: 0.1,
+});
 
-const X = [[-1.1], [0.3], [0.5], [100]];
-iForest.fit(X);
-const result = iForest.predict([[0.1], [0], [90]]);
-// [0, 0, 1]
+const trainingData = [[-1.1], [0.3], [0.5], [100]];
+isolationForest.fit(trainingData);
+
+const predictions = isolationForest.predict([[0.1], [0], [90]]);
+// predictions: [0, 0, 1] where 1 indicates an outlier
 ```
-## Documentation
 
-- [API References](apis/index.md)
+Isolation Forest isolates anomalies quickly by measuring the path length needed to separate each point. Use it for fraud detection, IoT monitoring, or surfacing suspicious product analytics trends. Continue learning with the [Ensemble module reference](apis/ensemble/index.md) to configure contamination thresholds and scoring utilities.
+
+## Explore the ecosystem
+
+| Topic | What you can build | Resources |
+| --- | --- | --- |
+| Clustering and segmentation | Customer cohorts, anomaly buckets, recommendation seeds | [Clusters API](apis/clusters/index.md) |
+| Dimensionality reduction | Feature compression, visualization prep, noise filtering | [Decomposition API](apis/decomposition/index.md) |
+| Predictive modeling | Regressions and classifiers for tabular or streaming data | [Linear](apis/linear/index.md), [Tree](apis/tree/index.md), [SVM](apis/svm/index.md) |
+| Deep learning basics | Lightweight neural networks for inference on the edge | [Neural Network module](apis/neural_network/index.md) |
+| Data preparation | Normalization, metrics, and helpers for production workflows | [Utils module](apis/utils/index.md) |
+
+For a complete view of available modules and helper utilities, head to the [full API reference](apis/index.md).
+
+## Learn by goal
+
+- **Ship to production faster** – Use the deployment checklist *(coming soon)* to package models for serverless or browser targets.
+- **Prototype interactive analytics** – Explore the [`examples`](../../../examples) directory for visual demos you can fork and customize.
+- **Master the fundamentals** – Read the upcoming Getting Started guide for an end-to-end project walkthrough, from dataset preparation to evaluation.
+
+## Stay connected
+
+- Watch the [project README](../../../README.md) for release notes, roadmap updates, and contribution guidelines.
+- Join the conversation in community channels to share feedback and learn from other @kanaries/ml practitioners.
+
+With these resources, you can build intelligent features that run entirely in JavaScript, experiment rapidly, and scale machine learning experiences across your product surface area.


### PR DESCRIPTION
## Summary
- expand the SEO plan with additional keywords, homepage priorities, and navigation refactor steps
- restructure the documentation homepage with clearer metadata, task-based navigation, and ecosystem highlights

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d26b5587708322a45f5294aa20bf7c